### PR TITLE
Actualiza content/es/index.md

### DIFF
--- a/content/es/index.md
+++ b/content/es/index.md
@@ -17,7 +17,7 @@ Descargar para:
 
 [Changelog](https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md)
 
-[Actualización semanal - 6 de Marzo][1] <small>constando de actualizaciones en core y la comunidad ([Medium][1])</small>
+[Actualización semanal - 6 de Marzo][1] <small>presentando actualizaciones en core y la comunidad ([Medium][1])</small>
 <br><br> [Nightly releases](https://iojs.org/download/nightly/) están disponibles para pruebas.
 
 [Preguntas frecuentes](faq.html)

--- a/content/es/index.md
+++ b/content/es/index.md
@@ -17,6 +17,9 @@ Descargar para:
 
 [Changelog](https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md)
 
-[Nightly releases](https://iojs.org/download/nightly/) están disponibles para pruebas.
+[Actualización semanal - 6 de Marzo][1] <small>constando de actualizaciones en core y la comunidad ([Medium][1])</small>
+<br><br> [Nightly releases](https://iojs.org/download/nightly/) están disponibles para pruebas.
 
 [Preguntas frecuentes](faq.html)
+
+[1]: https://medium.com/node-js-javascript/io-js-week-of-march-6th-2f9344688277


### PR DESCRIPTION
Han añadido un link a el artículo de la última semana. Original en [content/en/index.md](https://github.com/iojs-es/website/tree/master/content/en). Como el artículo de la semana pasada aún no esta traducido el link lo he dejado tal como estaba. Así que la PR de este cambio al iojs/website habrá que hacerla una vez @iojs-es/evangelizacion termine con la traducción que se dejó en iojs/iojs-es#101
